### PR TITLE
Support persistent watches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,12 @@ $(ZK):
 	tar -zxf $(ZK).tar.gz
 	rm $(ZK).tar.gz
 
+.PHONY: zookeeper
 zookeeper: $(ZK)
 	# we link to a standard directory path so then the tests dont need to find based on version
 	# in the test code. this allows backward compatable testing.
-	ln -s $(ZK) zookeeper
+	rm -f $@
+	ln -s $(ZK) $@
 
 .PHONY: setup
 setup: zookeeper

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # make file to hold the logic of build and test setup
-ZK_VERSION ?= 3.5.6
+ZK_VERSION ?= 3.6.3
 
 # Apache changed the name of the archive in version 3.5.x and seperated out
 # src and binary packages

--- a/conn.go
+++ b/conn.go
@@ -47,7 +47,13 @@ const (
 	watchTypeData watchType = iota
 	watchTypeExist
 	watchTypeChild
+	watchTypePersistent
+	watchTypePersistentRecursive
 )
+
+func (w watchType) isPersistent() bool {
+	return w == watchTypePersistent || w == watchTypePersistentRecursive
+}
 
 type watchPathType struct {
 	path  string
@@ -96,7 +102,7 @@ type Conn struct {
 	sendChan     chan *request
 	requests     map[int32]*request // Xid -> pending request
 	requestsLock sync.Mutex
-	watchers     map[watchPathType][]chan Event
+	watchers     map[watchPathType][]EventQueue
 	watchersLock sync.Mutex
 	closeChan    chan struct{} // channel to tell send loop stop
 
@@ -199,7 +205,7 @@ func Connect(servers []string, sessionTimeout time.Duration, options ...connOpti
 		connectTimeout: 1 * time.Second,
 		sendChan:       make(chan *request, sendChanSize),
 		requests:       make(map[int32]*request),
-		watchers:       make(map[watchPathType][]chan Event),
+		watchers:       make(map[watchPathType][]EventQueue),
 		passwd:         emptyPassword,
 		logger:         DefaultLogger,
 		logInfo:        true, // default is true for backwards compatability
@@ -530,29 +536,44 @@ func (c *Conn) flushRequests(err error) {
 	c.requestsLock.Unlock()
 }
 
+var eventWatchTypes = map[EventType][]watchType{
+	EventNodeCreated:         {watchTypeExist, watchTypePersistent, watchTypePersistentRecursive},
+	EventNodeDataChanged:     {watchTypeExist, watchTypeData, watchTypePersistent, watchTypePersistentRecursive},
+	EventNodeChildrenChanged: {watchTypeChild, watchTypePersistent},
+	EventNodeDeleted:         {watchTypeExist, watchTypeData, watchTypeChild, watchTypePersistent, watchTypePersistentRecursive},
+}
+var persistentWatchTypes = []watchType{watchTypePersistent, watchTypePersistentRecursive}
+
 // Send event to all interested watchers
 func (c *Conn) notifyWatches(ev Event) {
-	var wTypes []watchType
-	switch ev.Type {
-	case EventNodeCreated:
-		wTypes = []watchType{watchTypeExist}
-	case EventNodeDataChanged:
-		wTypes = []watchType{watchTypeExist, watchTypeData}
-	case EventNodeChildrenChanged:
-		wTypes = []watchType{watchTypeChild}
-	case EventNodeDeleted:
-		wTypes = []watchType{watchTypeExist, watchTypeData, watchTypeChild}
+	wTypes := eventWatchTypes[ev.Type]
+	if len(wTypes) == 0 {
+		return
 	}
+
 	c.watchersLock.Lock()
 	defer c.watchersLock.Unlock()
-	for _, t := range wTypes {
-		wpt := watchPathType{ev.Path, t}
-		if watchers := c.watchers[wpt]; len(watchers) > 0 {
-			for _, ch := range watchers {
-				ch <- ev
-				close(ch)
+
+	broadcast := func(wpt watchPathType) {
+		for _, ch := range c.watchers[wpt] {
+			ch.push(ev)
+			if !wpt.wType.isPersistent() {
+				ch.close()
 			}
 			delete(c.watchers, wpt)
+		}
+	}
+
+	for _, t := range wTypes {
+		if t == watchTypePersistentRecursive {
+			for p := ev.Path; ; p, _ = SplitPath(p) {
+				broadcast(watchPathType{p, t})
+				if p == "/" {
+					break
+				}
+			}
+		} else {
+			broadcast(watchPathType{ev.Path, t})
 		}
 	}
 }
@@ -562,16 +583,23 @@ func (c *Conn) invalidateWatches(err error) {
 	c.watchersLock.Lock()
 	defer c.watchersLock.Unlock()
 
-	if len(c.watchers) >= 0 {
+	if len(c.watchers) > 0 {
 		for pathType, watchers := range c.watchers {
+			if err == ErrSessionExpired && pathType.wType.isPersistent() {
+				// Ignore ErrSessionExpired for persistent watchers as the client will either automatically reconnect,
+				// or this is a shutdown-worthy error in which case there will be a followup invocation of this method
+				// with ErrClosing
+				continue
+			}
+
 			ev := Event{Type: EventNotWatching, State: StateDisconnected, Path: pathType.path, Err: err}
 			c.sendEvent(ev) // also publish globally
 			for _, ch := range watchers {
-				ch <- ev
-				close(ch)
+				ch.push(ev)
+				ch.close()
 			}
+			delete(c.watchers, pathType)
 		}
-		c.watchers = make(map[watchPathType][]chan Event)
 	}
 }
 
@@ -610,12 +638,7 @@ func (c *Conn) sendSetWatches() {
 				reqs = append(reqs, req)
 			}
 			sizeSoFar = 28 // fixed overhead of a set-watches packet
-			req = &setWatchesRequest{
-				RelativeZxid: c.lastZxid,
-				DataWatches:  make([]string, 0),
-				ExistWatches: make([]string, 0),
-				ChildWatches: make([]string, 0),
-			}
+			req = &setWatchesRequest{RelativeZxid: c.lastZxid}
 		}
 		sizeSoFar += addlLen
 		switch pathType.wType {
@@ -625,6 +648,10 @@ func (c *Conn) sendSetWatches() {
 			req.ExistWatches = append(req.ExistWatches, pathType.path)
 		case watchTypeChild:
 			req.ChildWatches = append(req.ChildWatches, pathType.path)
+		case watchTypePersistent:
+			req.PersistentWatches = append(req.PersistentWatches, pathType.path)
+		case watchTypePersistentRecursive:
+			req.PersistentRecursiveWatches = append(req.PersistentRecursiveWatches, pathType.path)
 		}
 		n++
 	}
@@ -646,7 +673,37 @@ func (c *Conn) sendSetWatches() {
 		// aren't failure modes where a blocking write to the channel of requests
 		// could hang indefinitely and cause this goroutine to leak...
 		for _, req := range reqs {
-			_, err := c.request(opSetWatches, req, res, nil)
+			var op int32 = opSetWatches
+			if len(req.PersistentWatches) > 0 || len(req.PersistentRecursiveWatches) > 0 {
+				// to maintain compatibility with older servers, only send opSetWatches2 if persistent watches are used
+				op = opSetWatches2
+			}
+
+			_, err := c.request(op, req, res, func(r *request, header *responseHeader, err error) {
+				if err == nil && op == opSetWatches2 {
+					// If the setWatches was successful, notify the persistent watchers they've been reconnected.
+					// Because we process responses in one routine, we know that the following will execute before
+					// subsequent responses are processed. This means we won't end up in a situation where events are
+					// sent to watchers before the reconnect event is sent.
+					c.watchersLock.Lock()
+					defer c.watchersLock.Unlock()
+					for _, wt := range persistentWatchTypes {
+						var paths []string
+						if wt == watchTypePersistent {
+							paths = req.PersistentWatches
+						} else {
+							paths = req.PersistentRecursiveWatches
+						}
+						for _, p := range paths {
+							e := Event{Type: EventWatching, State: StateConnected, Path: p}
+							c.sendEvent(e) // also publish globally
+							for _, ch := range c.watchers[watchPathType{path: p, wType: wt}] {
+								ch.push(e)
+							}
+						}
+					}
+				}
+			})
 			if err != nil {
 				c.logger.Printf("Failed to set previous watches: %v", err)
 				break
@@ -827,15 +884,15 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 		}
 
 		if res.Xid == -1 {
-			res := &watcherEvent{}
-			_, err = decodePacket(buf[16:blen], res)
+			we := &watcherEvent{}
+			_, err = decodePacket(buf[16:blen], we)
 			if err != nil {
 				return err
 			}
 			ev := Event{
-				Type:  res.Type,
-				State: res.State,
-				Path:  res.Path,
+				Type:  we.Type,
+				State: we.State,
+				Path:  we.Path,
 				Err:   nil,
 			}
 			c.sendEvent(ev)
@@ -880,14 +937,15 @@ func (c *Conn) nextXid() int32 {
 	return int32(atomic.AddUint32(&c.xid, 1) & 0x7fffffff)
 }
 
-func (c *Conn) addWatcher(path string, watchType watchType) <-chan Event {
+func (c *Conn) addWatcher(path string, watchType watchType, ch EventQueue) {
 	c.watchersLock.Lock()
 	defer c.watchersLock.Unlock()
 
-	ch := make(chan Event, 1)
 	wpt := watchPathType{path, watchType}
 	c.watchers[wpt] = append(c.watchers[wpt], ch)
-	return ch
+	if watchType.isPersistent() {
+		ch.push(Event{Type: EventWatching, State: StateConnected, Path: path})
+	}
 }
 
 func (c *Conn) queueRequest(opcode int32, req interface{}, res interface{}, recvFunc func(*request, *responseHeader, error)) <-chan response {
@@ -981,7 +1039,7 @@ func (c *Conn) Children(path string) ([]string, *Stat, error) {
 	if err == ErrConnectionClosed {
 		return nil, nil, err
 	}
-	return res.Children, &res.Stat, err
+	return res.Children, res.Stat, err
 }
 
 // ChildrenW returns the children of a znode and sets a watch.
@@ -990,17 +1048,18 @@ func (c *Conn) ChildrenW(path string) ([]string, *Stat, <-chan Event, error) {
 		return nil, nil, nil, err
 	}
 
-	var ech <-chan Event
+	var ech chanEventQueue
 	res := &getChildren2Response{}
 	_, err := c.request(opGetChildren2, &getChildren2Request{Path: path, Watch: true}, res, func(req *request, res *responseHeader, err error) {
 		if err == nil {
-			ech = c.addWatcher(path, watchTypeChild)
+			ech = newChanEventChannel()
+			c.addWatcher(path, watchTypeChild, ech)
 		}
 	})
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return res.Children, &res.Stat, ech, err
+	return res.Children, res.Stat, ech, err
 }
 
 // Get gets the contents of a znode.
@@ -1014,7 +1073,7 @@ func (c *Conn) Get(path string) ([]byte, *Stat, error) {
 	if err == ErrConnectionClosed {
 		return nil, nil, err
 	}
-	return res.Data, &res.Stat, err
+	return res.Data, res.Stat, err
 }
 
 // GetW returns the contents of a znode and sets a watch
@@ -1023,17 +1082,18 @@ func (c *Conn) GetW(path string) ([]byte, *Stat, <-chan Event, error) {
 		return nil, nil, nil, err
 	}
 
-	var ech <-chan Event
+	var ech chanEventQueue
 	res := &getDataResponse{}
 	_, err := c.request(opGetData, &getDataRequest{Path: path, Watch: true}, res, func(req *request, res *responseHeader, err error) {
 		if err == nil {
-			ech = c.addWatcher(path, watchTypeData)
+			ech = newChanEventChannel()
+			c.addWatcher(path, watchTypeData, ech)
 		}
 	})
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return res.Data, &res.Stat, ech, err
+	return res.Data, res.Stat, ech, err
 }
 
 // Set updates the contents of a znode.
@@ -1047,10 +1107,10 @@ func (c *Conn) Set(path string, data []byte, version int32) (*Stat, error) {
 	if err == ErrConnectionClosed {
 		return nil, err
 	}
-	return &res.Stat, err
+	return res.Stat, err
 }
 
-// Create creates a znode.
+// Create creates a znode. If acl is empty, it uses the global WorldACL with PermAll
 // The returned path is the new path assigned by the server, it may not be the
 // same as the input, for example when creating a sequence znode the returned path
 // will be the input path with a sequence number appended.
@@ -1059,12 +1119,34 @@ func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string,
 		return "", err
 	}
 
+	if len(acl) == 0 {
+		acl = WorldACL(PermAll)
+	}
+
 	res := &createResponse{}
 	_, err := c.request(opCreate, &CreateRequest{path, data, acl, flags}, res, nil)
 	if err == ErrConnectionClosed {
 		return "", err
 	}
 	return res.Path, err
+}
+
+// CreateAndReturnStat is the equivalent of Create, but it also returns the Stat of the created node.
+func (c *Conn) CreateAndReturnStat(path string, data []byte, flags int32, acl []ACL) (string, *Stat, error) {
+	if err := validatePath(path, flags&FlagSequence == FlagSequence); err != nil {
+		return "", nil, err
+	}
+
+	if len(acl) == 0 {
+		acl = WorldACL(PermAll)
+	}
+
+	res := &create2Response{}
+	_, err := c.request(opCreate2, &CreateRequest{path, data, acl, flags}, res, nil)
+	if err == ErrConnectionClosed {
+		return "", nil, err
+	}
+	return res.Path, res.Stat, err
 }
 
 // CreateContainer creates a container znode and returns the path.
@@ -1170,7 +1252,7 @@ func (c *Conn) Exists(path string) (bool, *Stat, error) {
 		exists = false
 		err = nil
 	}
-	return exists, &res.Stat, err
+	return exists, res.Stat, err
 }
 
 // ExistsW tells the existence of a znode and sets a watch.
@@ -1179,13 +1261,14 @@ func (c *Conn) ExistsW(path string) (bool, *Stat, <-chan Event, error) {
 		return false, nil, nil, err
 	}
 
-	var ech <-chan Event
+	var ech chanEventQueue
 	res := &existsResponse{}
 	_, err := c.request(opExists, &existsRequest{Path: path, Watch: true}, res, func(req *request, res *responseHeader, err error) {
+		ech = newChanEventChannel()
 		if err == nil {
-			ech = c.addWatcher(path, watchTypeData)
+			c.addWatcher(path, watchTypeData, ech)
 		} else if err == ErrNoNode {
-			ech = c.addWatcher(path, watchTypeExist)
+			c.addWatcher(path, watchTypeExist, ech)
 		}
 	})
 	exists := true
@@ -1196,7 +1279,7 @@ func (c *Conn) ExistsW(path string) (bool, *Stat, <-chan Event, error) {
 	if err != nil {
 		return false, nil, nil, err
 	}
-	return exists, &res.Stat, ech, err
+	return exists, res.Stat, ech, err
 }
 
 // GetACL gets the ACLs of a znode.
@@ -1210,7 +1293,7 @@ func (c *Conn) GetACL(path string) ([]ACL, *Stat, error) {
 	if err == ErrConnectionClosed {
 		return nil, nil, err
 	}
-	return res.Acl, &res.Stat, err
+	return res.Acl, res.Stat, err
 }
 
 // SetACL updates the ACLs of a znode.
@@ -1224,7 +1307,7 @@ func (c *Conn) SetACL(path string, acl []ACL, version int32) (*Stat, error) {
 	if err == ErrConnectionClosed {
 		return nil, err
 	}
-	return &res.Stat, err
+	return res.Stat, err
 }
 
 // Sync flushes the channel between process and the leader of a given znode,
@@ -1255,8 +1338,7 @@ type MultiResponse struct {
 // *CheckVersionRequest.
 func (c *Conn) Multi(ops ...interface{}) ([]MultiResponse, error) {
 	req := &multiRequest{
-		Ops:        make([]multiRequestOp, 0, len(ops)),
-		DoneHeader: multiHeader{Type: -1, Done: true, Err: -1},
+		Ops: make([]multiRequestOp, 0, len(ops)),
 	}
 	for _, op := range ops {
 		var opCode int32
@@ -1284,6 +1366,44 @@ func (c *Conn) Multi(ops ...interface{}) ([]MultiResponse, error) {
 		mr[i] = MultiResponse{Stat: op.Stat, String: op.String, Error: op.Err.toError()}
 	}
 	return mr, err
+}
+
+// MultiRead executes multiple ZooKeeper read operations at once. The provided ops must be one of GetDataOp or
+// GetChildrenOp. Returns an error on network or connectivity errors, not on any op errors such as ErrNoNode. To check
+// if any ops failed, check the corresponding MultiReadResponse.Err.
+func (c *Conn) MultiRead(ops ...ReadOp) ([]MultiReadResponse, error) {
+	req := &multiRequest{
+		Ops: make([]multiRequestOp, len(ops)),
+	}
+	for i, op := range ops {
+		req.Ops[i] = multiRequestOp{
+			Header: multiHeader{op.opCode(), false, -1},
+			Op:     pathWatchRequest{Path: op.GetPath()},
+		}
+	}
+	res := &multiReadResponse{}
+	_, err := c.request(opMultiRead, req, res, nil)
+	return res.OpResults, err
+}
+
+// GetDataAndChildren executes a multi-read to get the given node's data and its children in one call.
+func (c *Conn) GetDataAndChildren(path string) ([]byte, *Stat, []string, error) {
+	if err := validatePath(path, false); err != nil {
+		return nil, nil, nil, err
+	}
+
+	opResults, err := c.MultiRead(GetDataOp(path), GetChildrenOp(path))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	for _, r := range opResults {
+		if r.Err != nil {
+			return nil, nil, nil, r.Err
+		}
+	}
+
+	return opResults[0].Data, opResults[0].Stat, opResults[1].Children, nil
 }
 
 // IncrementalReconfig is the zookeeper reconfiguration api that allows adding and removing servers
@@ -1321,7 +1441,7 @@ func (c *Conn) Reconfig(members []string, version int64) (*Stat, error) {
 func (c *Conn) internalReconfig(request *reconfigRequest) (*Stat, error) {
 	response := &reconfigReponse{}
 	_, err := c.request(opReconfig, request, response, nil)
-	return &response.Stat, err
+	return response.Stat, err
 }
 
 // Server returns the current or last-connected server name.
@@ -1329,6 +1449,97 @@ func (c *Conn) Server() string {
 	c.serverMu.Lock()
 	defer c.serverMu.Unlock()
 	return c.server
+}
+
+func (c *Conn) AddPersistentWatch(path string, mode AddWatchMode) (ch EventQueue, err error) {
+	if err = validatePath(path, false); err != nil {
+		return nil, err
+	}
+
+	res := &addWatchResponse{}
+	_, err = c.request(opAddWatch, &addWatchRequest{Path: path, Mode: mode}, res, func(r *request, header *responseHeader, err error) {
+		if err == nil {
+			var wt watchType
+			if mode == AddWatchModePersistent {
+				wt = watchTypePersistent
+			} else {
+				wt = watchTypePersistentRecursive
+			}
+
+			ch = newUnlimitedEventQueue()
+			c.addWatcher(path, wt, ch)
+		}
+	})
+	if err == ErrConnectionClosed {
+		return nil, err
+	}
+	return ch, err
+}
+
+func (c *Conn) RemovePersistentWatch(path string, ch EventQueue) (err error) {
+	if err = validatePath(path, false); err != nil {
+		return err
+	}
+
+	deleted := false
+
+	res := &checkWatchesResponse{}
+	_, err = c.request(opCheckWatches, &checkWatchesRequest{Path: path, Type: WatcherTypeAny}, res, func(r *request, header *responseHeader, err error) {
+		if err != nil {
+			return
+		}
+
+		c.watchersLock.Lock()
+		defer c.watchersLock.Unlock()
+
+		for _, wt := range persistentWatchTypes {
+			wpt := watchPathType{path: path, wType: wt}
+			for i, w := range c.watchers[wpt] {
+				if w == ch {
+					deleted = true
+					c.watchers[wpt] = append(c.watchers[wpt][:i], c.watchers[wpt][i+1:]...)
+					w.push(Event{Type: EventNotWatching, State: c.State(), Path: path, Err: ErrNoWatcher})
+					w.close()
+					return
+				}
+			}
+		}
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if !deleted {
+		return ErrNoWatcher
+	}
+
+	return nil
+}
+
+func (c *Conn) RemoveAllPersistentWatches(path string) (err error) {
+	if err = validatePath(path, false); err != nil {
+		return err
+	}
+
+	res := &checkWatchesResponse{}
+	_, err = c.request(opRemoveWatches, &checkWatchesRequest{Path: path, Type: WatcherTypeAny}, res, func(r *request, header *responseHeader, err error) {
+		if err != nil {
+			return
+		}
+
+		c.watchersLock.Lock()
+		defer c.watchersLock.Unlock()
+		for _, wt := range persistentWatchTypes {
+			wpt := watchPathType{path: path, wType: wt}
+			for _, ch := range c.watchers[wpt] {
+				ch.push(Event{Type: EventNotWatching, State: c.State(), Path: path, Err: ErrNoWatcher})
+				ch.close()
+			}
+			delete(c.watchers, wpt)
+		}
+	})
+	return err
 }
 
 func resendZkAuth(ctx context.Context, c *Conn) error {
@@ -1388,4 +1599,24 @@ func resendZkAuth(ctx context.Context, c *Conn) error {
 	}
 
 	return nil
+}
+
+func JoinPath(parent, child string) string {
+	if !strings.HasSuffix(parent, "/") {
+		parent += "/"
+	}
+	if strings.HasPrefix(child, "/") {
+		child = child[1:]
+	}
+	return parent + child
+}
+
+func SplitPath(path string) (dir, name string) {
+	i := strings.LastIndex(path, "/")
+	if i == 0 {
+		dir, name = "/", path[1:]
+	} else {
+		dir, name = path[:i], path[i+1:]
+	}
+	return dir, name
 }

--- a/conn.go
+++ b/conn.go
@@ -996,10 +996,10 @@ func (c *Conn) queueRequest(opcode int32, req interface{}, res interface{}, recv
 	return rq.recvChan
 }
 
-func (c *Conn) request(opcode int32, req interface{}, res interface{}, recvFunc func(*request, *responseHeader, error)) (int64, error) {
+func (c *Conn) request(opcode int32, req interface{}, res interface{}, recvFunc func(*request, *responseHeader, error)) (_ int64, err error) {
 	start := time.Now()
 	defer func() {
-		c.metricReceiver.RequestCompleted(time.Now().Sub(start))
+		c.metricReceiver.RequestCompleted(time.Now().Sub(start), err)
 	}()
 
 	recv := c.queueRequest(opcode, req, res, recvFunc)

--- a/constants.go
+++ b/constants.go
@@ -26,12 +26,18 @@ const (
 	opGetChildren2    = 12
 	opCheck           = 13
 	opMulti           = 14
+	opCreate2         = 15
 	opReconfig        = 16
+	opCheckWatches    = 17
+	opRemoveWatches   = 18
 	opCreateContainer = 19
 	opCreateTTL       = 21
+	opMultiRead       = 22
 	opClose           = -11
 	opSetAuth         = 100
 	opSetWatches      = 101
+	opSetWatches2     = 105
+	opAddWatch        = 106
 	opError           = -1
 	// Not in protocol, used internally
 	opWatcherEvent = -2
@@ -47,6 +53,7 @@ const (
 	// EventSession represents a session event.
 	EventSession     EventType = -1
 	EventNotWatching EventType = -2
+	EventWatching    EventType = -3
 )
 
 var (
@@ -57,6 +64,7 @@ var (
 		EventNodeChildrenChanged: "EventNodeChildrenChanged",
 		EventSession:             "EventSession",
 		EventNotWatching:         "EventNotWatching",
+		EventWatching:            "EventWatching",
 	}
 )
 
@@ -129,6 +137,8 @@ var (
 	ErrSessionMoved            = errors.New("zk: session moved to another server, so operation is ignored")
 	ErrReconfigDisabled        = errors.New("attempts to perform a reconfiguration operation when reconfiguration feature is disabled")
 	ErrBadArguments            = errors.New("invalid arguments")
+	ErrNoWatcher               = errors.New("zk: no such watcher")
+	ErrUnimplemented           = errors.New("zk: Not implemented")
 	// ErrInvalidCallback         = errors.New("zk: invalid callback specified")
 
 	errCodeToError = map[ErrCode]error{
@@ -147,8 +157,10 @@ var (
 		errClosing:           ErrClosing,
 		errNothing:           ErrNothing,
 		errSessionMoved:      ErrSessionMoved,
+		errNoWatcher:         ErrNoWatcher,
 		errZReconfigDisabled: ErrReconfigDisabled,
 		errBadArguments:      ErrBadArguments,
+		errUnimplemented:     ErrUnimplemented,
 	}
 )
 
@@ -186,6 +198,7 @@ const (
 	errClosing                 ErrCode = -116
 	errNothing                 ErrCode = -117
 	errSessionMoved            ErrCode = -118
+	errNoWatcher               ErrCode = -121
 	// Attempts to perform a reconfiguration operation when reconfiguration feature is disabled
 	errZReconfigDisabled ErrCode = -123
 )
@@ -224,6 +237,7 @@ var (
 		opClose:           "close",
 		opSetAuth:         "setAuth",
 		opSetWatches:      "setWatches",
+		opAddWatch:        "addWatch",
 
 		opWatcherEvent: "watcherEvent",
 	}
@@ -262,4 +276,34 @@ var (
 		ModeFollower:   "follower",
 		ModeStandalone: "standalone",
 	}
+)
+
+// AddWatchMode asd
+type AddWatchMode int32
+
+func (m AddWatchMode) String() string {
+	if name, ok := addWatchModeNames[m]; ok {
+		return name
+	}
+	return "unknown"
+}
+
+const (
+	AddWatchModePersistent          AddWatchMode = iota
+	AddWatchModePersistentRecursive AddWatchMode = iota
+)
+
+var (
+	addWatchModeNames = map[AddWatchMode]string{
+		AddWatchModePersistent:          "persistent",
+		AddWatchModePersistentRecursive: "persistentRecursive",
+	}
+)
+
+type WatcherType int32
+
+const (
+	WatcherTypeChildren = WatcherType(1)
+	WatcherTypeData     = WatcherType(2)
+	WatcherTypeAny      = WatcherType(3)
 )

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/go-zookeeper/zk
+module github.com/PapaCharlie/zk
 
-go 1.13
+go 1.18

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,20 @@
+package zk
+
+import (
+	"time"
+)
+
+type MetricReceiver interface {
+	PingSent()
+	PongReceived()
+	RequestCompleted(duration time.Duration)
+}
+
+var _ MetricReceiver = UnimplementedMetricReceiver{}
+
+type UnimplementedMetricReceiver struct {
+}
+
+func (u UnimplementedMetricReceiver) PingSent()                      {}
+func (u UnimplementedMetricReceiver) PongReceived()                  {}
+func (u UnimplementedMetricReceiver) RequestCompleted(time.Duration) {}

--- a/metrics.go
+++ b/metrics.go
@@ -7,7 +7,7 @@ import (
 type MetricReceiver interface {
 	PingSent()
 	PongReceived()
-	RequestCompleted(duration time.Duration)
+	RequestCompleted(duration time.Duration, err error)
 }
 
 var _ MetricReceiver = UnimplementedMetricReceiver{}
@@ -15,6 +15,6 @@ var _ MetricReceiver = UnimplementedMetricReceiver{}
 type UnimplementedMetricReceiver struct {
 }
 
-func (u UnimplementedMetricReceiver) PingSent()                      {}
-func (u UnimplementedMetricReceiver) PongReceived()                  {}
-func (u UnimplementedMetricReceiver) RequestCompleted(time.Duration) {}
+func (u UnimplementedMetricReceiver) PingSent()                             {}
+func (u UnimplementedMetricReceiver) PongReceived()                         {}
+func (u UnimplementedMetricReceiver) RequestCompleted(time.Duration, error) {}

--- a/structs_test.go
+++ b/structs_test.go
@@ -10,7 +10,7 @@ func TestEncodeDecodePacket(t *testing.T) {
 	encodeDecodeTest(t, &requestHeader{-2, 5})
 	encodeDecodeTest(t, &connectResponse{1, 2, 3, nil})
 	encodeDecodeTest(t, &connectResponse{1, 2, 3, []byte{4, 5, 6}})
-	encodeDecodeTest(t, &getAclResponse{[]ACL{{12, "s", "anyone"}}, Stat{}})
+	encodeDecodeTest(t, &getAclResponse{[]ACL{{12, "s", "anyone"}}, &Stat{}})
 	encodeDecodeTest(t, &getChildrenResponse{[]string{"foo", "bar"}})
 	encodeDecodeTest(t, &pathWatchRequest{"path", true})
 	encodeDecodeTest(t, &pathWatchRequest{"path", false})

--- a/unlimited_channel.go
+++ b/unlimited_channel.go
@@ -1,0 +1,104 @@
+//go:build go1.18
+// +build go1.18
+
+package zk
+
+import (
+	"sync"
+)
+
+type EventQueue interface {
+	Next() <-chan Event
+	push(e Event)
+	close()
+}
+
+type chanEventQueue chan Event
+
+func (c chanEventQueue) Next() <-chan Event {
+	return c
+}
+
+func (c chanEventQueue) push(e Event) {
+	c <- e
+}
+
+func (c chanEventQueue) close() {
+	close(c)
+}
+
+func newChanEventChannel() chanEventQueue {
+	return make(chan Event, 1)
+}
+
+func newUnlimitedChannelNode() *unlimitedEventQueueNode {
+	return &unlimitedEventQueueNode{event: make(chan Event, 1)}
+}
+
+type unlimitedEventQueueNode struct {
+	event chan Event
+	next  *unlimitedEventQueueNode
+}
+
+type unlimitedEventQueue struct {
+	lock sync.Mutex
+	head *unlimitedEventQueueNode
+	tail *unlimitedEventQueueNode
+}
+
+// newUnlimitedEventQueue uses a backing unlimitedEventQueue used to effectively turn a buffered channel into a channel
+// with an infinite buffer by storing all incoming elements into a singly-linked queue and popping them as they are
+// read.
+func newUnlimitedEventQueue() *unlimitedEventQueue {
+	head := newUnlimitedChannelNode()
+	q := &unlimitedEventQueue{
+		head: head,
+		tail: head,
+	}
+	return q
+}
+
+func (q *unlimitedEventQueue) push(e Event) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	if q.tail == nil {
+		// Panic like a closed channel
+		panic("send on closed unlimited channel")
+	}
+
+	next := newUnlimitedChannelNode()
+	tail := q.tail
+	tail.next = next
+	q.tail = next
+	tail.event <- e
+}
+
+func (q *unlimitedEventQueue) close() {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	close(q.tail.event)
+	q.tail = nil
+}
+
+var closedChannel = func() <-chan Event {
+	ch := make(chan Event)
+	close(ch)
+	return ch
+}()
+
+func (q *unlimitedEventQueue) Next() <-chan Event {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	if q.head == nil && q.tail == nil {
+		return closedChannel
+	}
+
+	node := q.head
+	if node.next == nil {
+		node.next = newUnlimitedChannelNode()
+	}
+	q.head = q.head.next
+	return node.event
+}

--- a/unlimited_channel.go
+++ b/unlimited_channel.go
@@ -1,22 +1,32 @@
-//go:build go1.18
-// +build go1.18
-
 package zk
 
 import (
+	"context"
+	"errors"
 	"sync"
 )
 
+var ErrEventQueueClosed = errors.New("zk: event queue closed")
+
 type EventQueue interface {
-	Next() <-chan Event
+	Next(ctx context.Context) (Event, error)
 	push(e Event)
 	close()
 }
 
 type chanEventQueue chan Event
 
-func (c chanEventQueue) Next() <-chan Event {
-	return c
+func (c chanEventQueue) Next(ctx context.Context) (Event, error) {
+	select {
+	case <-ctx.Done():
+		return Event{}, ctx.Err()
+	case e, ok := <-c:
+		if !ok {
+			return Event{}, ErrEventQueueClosed
+		} else {
+			return e, nil
+		}
+	}
 }
 
 func (c chanEventQueue) push(e Event) {
@@ -31,74 +41,67 @@ func newChanEventChannel() chanEventQueue {
 	return make(chan Event, 1)
 }
 
-func newUnlimitedChannelNode() *unlimitedEventQueueNode {
-	return &unlimitedEventQueueNode{event: make(chan Event, 1)}
-}
-
-type unlimitedEventQueueNode struct {
-	event chan Event
-	next  *unlimitedEventQueueNode
-}
-
 type unlimitedEventQueue struct {
-	lock sync.Mutex
-	head *unlimitedEventQueueNode
-	tail *unlimitedEventQueueNode
+	lock     sync.Mutex
+	newEvent chan struct{}
+	events   []Event
 }
 
-// newUnlimitedEventQueue uses a backing unlimitedEventQueue used to effectively turn a buffered channel into a channel
-// with an infinite buffer by storing all incoming elements into a singly-linked queue and popping them as they are
-// read.
 func newUnlimitedEventQueue() *unlimitedEventQueue {
-	head := newUnlimitedChannelNode()
-	q := &unlimitedEventQueue{
-		head: head,
-		tail: head,
+	return &unlimitedEventQueue{
+		newEvent: make(chan struct{}),
 	}
-	return q
 }
 
 func (q *unlimitedEventQueue) push(e Event) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	if q.tail == nil {
+	if q.newEvent == nil {
 		// Panic like a closed channel
 		panic("send on closed unlimited channel")
 	}
 
-	next := newUnlimitedChannelNode()
-	tail := q.tail
-	tail.next = next
-	q.tail = next
-	tail.event <- e
+	q.events = append(q.events, e)
+	close(q.newEvent)
+	q.newEvent = make(chan struct{})
 }
 
 func (q *unlimitedEventQueue) close() {
 	q.lock.Lock()
 	defer q.lock.Unlock()
-	close(q.tail.event)
-	q.tail = nil
+
+	if q.newEvent == nil {
+		// Panic like a closed channel
+		panic("close of closed EventQueue")
+	}
+
+	close(q.newEvent)
+	q.newEvent = nil
 }
 
-var closedChannel = func() <-chan Event {
-	ch := make(chan Event)
-	close(ch)
-	return ch
-}()
+func (q *unlimitedEventQueue) Next(ctx context.Context) (Event, error) {
+	for {
+		q.lock.Lock()
+		if len(q.events) > 0 {
+			e := q.events[0]
+			q.events = q.events[1:]
+			q.lock.Unlock()
+			return e, nil
+		}
 
-func (q *unlimitedEventQueue) Next() <-chan Event {
-	q.lock.Lock()
-	defer q.lock.Unlock()
+		ch := q.newEvent
+		if ch == nil {
+			q.lock.Unlock()
+			return Event{}, ErrEventQueueClosed
+		}
+		q.lock.Unlock()
 
-	if q.head == nil && q.tail == nil {
-		return closedChannel
+		select {
+		case <-ctx.Done():
+			return Event{}, ctx.Err()
+		case <-ch:
+			continue
+		}
 	}
-
-	node := q.head
-	if node.next == nil {
-		node.next = newUnlimitedChannelNode()
-	}
-	q.head = q.head.next
-	return node.event
 }

--- a/unlimited_channel_test.go
+++ b/unlimited_channel_test.go
@@ -1,0 +1,63 @@
+//go:build go1.18
+
+package zk
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func newEvent(i int) Event {
+	return Event{Path: fmt.Sprintf("/%d", i)}
+}
+
+func TestUnlimitedChannel(t *testing.T) {
+	names := []string{"notClosedAfterPushes", "closeAfterPushes"}
+	for i, closeAfterPushes := range []bool{false, true} {
+		t.Run(names[i], func(t *testing.T) {
+			ch := newUnlimitedEventQueue()
+			const eventCount = 2
+
+			// check that events can be pushed without consumers
+			for i := 0; i < eventCount; i++ {
+				ch.push(newEvent(i))
+			}
+			if closeAfterPushes {
+				ch.close()
+			}
+
+			events := 0
+			for {
+				actual, ok := <-ch.Next()
+				expected := newEvent(events)
+				if !reflect.DeepEqual(actual, expected) {
+					t.Fatalf("Did not receive expected event from queue (ok: %+v): actual %+v expected %+v",
+						ok, actual, expected)
+				}
+				events++
+				if events == eventCount {
+					if closeAfterPushes {
+						select {
+						case _, ok := <-ch.Next():
+							if ok {
+								t.Fatal("Next did not return closed channel")
+							}
+						case <-time.After(time.Second):
+							t.Fatal("Next never closed")
+						}
+					} else {
+						select {
+						case e, ok := <-ch.Next():
+							t.Fatalf("Next received unexpected value (%+v) or was closed (%+v)", e, ok)
+						case <-time.After(time.Millisecond * 10):
+							return
+						}
+					}
+					break
+				}
+			}
+		})
+	}
+}

--- a/watch.go
+++ b/watch.go
@@ -1,0 +1,1 @@
+package zk

--- a/watch_test.go
+++ b/watch_test.go
@@ -1,0 +1,1 @@
+package zk

--- a/zk_test.go
+++ b/zk_test.go
@@ -2,7 +2,6 @@ package zk
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -187,27 +186,22 @@ func TestCreateContainer(t *testing.T) {
 }
 
 func TestIncrementalReconfig(t *testing.T) {
-	if val, ok := os.LookupEnv("zk_version"); ok {
-		if !strings.HasPrefix(val, "3.5") {
-			t.Skip("running with zookeeper that does not support this api")
-		}
-	} else {
-		t.Skip("did not detect zk_version from env. skipping reconfig test")
-	}
+	RequireMinimumZkVersion(t, "3.5")
+
 	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
-	requireNoError(t, err, "failed to setup test cluster")
+	requireNoErrorf(t, err, "failed to setup test cluster")
 	defer ts.Stop()
 
 	// start and add a new server.
 	tmpPath, err := ioutil.TempDir("", "gozk")
-	requireNoError(t, err, "failed to create tmp dir for test server setup")
+	requireNoErrorf(t, err, "failed to create tmp dir for test server setup")
 	defer os.RemoveAll(tmpPath)
 
 	startPort := int(rand.Int31n(6000) + 10000)
 
 	srvPath := filepath.Join(tmpPath, fmt.Sprintf("srv4"))
 	if err := os.Mkdir(srvPath, 0700); err != nil {
-		requireNoError(t, err, "failed to make server path")
+		requireNoErrorf(t, err, "failed to make server path")
 	}
 	testSrvConfig := ServerConfigServer{
 		ID:                 4,
@@ -224,35 +218,35 @@ func TestIncrementalReconfig(t *testing.T) {
 	// TODO: clean all this server creating up to a better helper method
 	cfgPath := filepath.Join(srvPath, _testConfigName)
 	fi, err := os.Create(cfgPath)
-	requireNoError(t, err)
+	requireNoErrorf(t, err)
 
-	requireNoError(t, cfg.Marshall(fi))
+	requireNoErrorf(t, cfg.Marshall(fi))
 	fi.Close()
 
 	fi, err = os.Create(filepath.Join(srvPath, _testMyIDFileName))
-	requireNoError(t, err)
+	requireNoErrorf(t, err)
 
 	_, err = fmt.Fprintln(fi, "4")
 	fi.Close()
-	requireNoError(t, err)
+	requireNoErrorf(t, err)
 
 	testServer, err := NewIntegrationTestServer(t, cfgPath, nil, nil)
-	requireNoError(t, err)
-	requireNoError(t, testServer.Start())
+	requireNoErrorf(t, err)
+	requireNoErrorf(t, testServer.Start())
 	defer testServer.Stop()
 
 	zk, events, err := ts.ConnectAll()
-	requireNoError(t, err, "failed to connect to cluster")
+	requireNoErrorf(t, err, "failed to connect to cluster")
 	defer zk.Close()
 
 	err = zk.AddAuth("digest", []byte("super:test"))
-	requireNoError(t, err, "failed to auth to cluster")
+	requireNoErrorf(t, err, "failed to auth to cluster")
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	err = waitForSession(waitCtx, events)
-	requireNoError(t, err, "failed to wail for session")
+	requireNoErrorf(t, err, "failed to wail for session")
 
 	_, _, err = zk.Get("/zookeeper/config")
 	if err != nil {
@@ -268,7 +262,7 @@ func TestIncrementalReconfig(t *testing.T) {
 	if err != nil && err == ErrConnectionClosed {
 		t.Log("conneciton closed is fine since the cluster re-elects and we dont reconnect")
 	} else {
-		requireNoError(t, err, "failed to remove node from cluster")
+		requireNoErrorf(t, err, "failed to remove node from cluster")
 	}
 
 	// add node a new 4th node
@@ -277,36 +271,30 @@ func TestIncrementalReconfig(t *testing.T) {
 	if err != nil && err == ErrConnectionClosed {
 		t.Log("conneciton closed is fine since the cluster re-elects and we dont reconnect")
 	} else {
-		requireNoError(t, err, "failed to add new server to cluster")
+		requireNoErrorf(t, err, "failed to add new server to cluster")
 	}
 }
 
 func TestReconfig(t *testing.T) {
-	if val, ok := os.LookupEnv("zk_version"); ok {
-		if !strings.HasPrefix(val, "3.5") {
-			t.Skip("running with zookeeper that does not support this api")
-		}
-	} else {
-		t.Skip("did not detect zk_version from env. skipping reconfig test")
-	}
+	RequireMinimumZkVersion(t, "3.5")
 
 	// This test enures we can do an non-incremental reconfig
 	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
-	requireNoError(t, err, "failed to setup test cluster")
+	requireNoErrorf(t, err, "failed to setup test cluster")
 	defer ts.Stop()
 
 	zk, events, err := ts.ConnectAll()
-	requireNoError(t, err, "failed to connect to cluster")
+	requireNoErrorf(t, err, "failed to connect to cluster")
 	defer zk.Close()
 
 	err = zk.AddAuth("digest", []byte("super:test"))
-	requireNoError(t, err, "failed to auth to cluster")
+	requireNoErrorf(t, err, "failed to auth to cluster")
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	err = waitForSession(waitCtx, events)
-	requireNoError(t, err, "failed to wail for session")
+	requireNoErrorf(t, err, "failed to wail for session")
 
 	_, _, err = zk.Get("/zookeeper/config")
 	if err != nil {
@@ -320,7 +308,7 @@ func TestReconfig(t *testing.T) {
 	}
 
 	_, err = zk.Reconfig(s, -1)
-	requireNoError(t, err, "failed to reconfig cluster")
+	requireNoErrorf(t, err, "failed to reconfig cluster")
 
 	// reconfig to all the hosts again
 	s = []string{}
@@ -329,7 +317,7 @@ func TestReconfig(t *testing.T) {
 	}
 
 	_, err = zk.Reconfig(s, -1)
-	requireNoError(t, err, "failed to reconfig cluster")
+	requireNoErrorf(t, err, "failed to reconfig cluster")
 }
 
 func TestOpsAfterCloseDontDeadlock(t *testing.T) {
@@ -604,6 +592,7 @@ func TestAuth(t *testing.T) {
 	}
 }
 
+// Tests that we correctly handle a response larger than the default buffer size
 func TestChildren(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
@@ -622,38 +611,44 @@ func TestChildren(t *testing.T) {
 		}
 	}
 
-	deleteNode("/gozk-test-big")
+	testNode := "/gozk-test-big"
+	deleteNode(testNode)
 
-	if path, err := zk.Create("/gozk-test-big", []byte{1, 2, 3, 4}, 0, WorldACL(PermAll)); err != nil {
+	if _, err := zk.Create(testNode, nil, 0, WorldACL(PermAll)); err != nil {
 		t.Fatalf("Create returned error: %+v", err)
-	} else if path != "/gozk-test-big" {
-		t.Fatalf("Create returned different path '%s' != '/gozk-test-big'", path)
 	}
 
-	rb := make([]byte, 1000)
-	hb := make([]byte, 2000)
-	prefix := []byte("/gozk-test-big/")
-	for i := 0; i < 10000; i++ {
-		_, err := rand.Read(rb)
-		if err != nil {
-			t.Fatal("Cannot create random znode name")
-		}
-		hex.Encode(hb, rb)
+	const (
+		nodesToCreate = 100
+		// By creating many nodes with long names, the response from the Children call should be significantly longer
+		// than the buffer size, forcing recvLoop to allocate a bigger buffer
+		nameLength = 2 * bufferSize / nodesToCreate
+	)
 
-		expect := string(append(prefix, hb...))
-		if path, err := zk.Create(expect, []byte{1, 2, 3, 4}, 0, WorldACL(PermAll)); err != nil {
+	format := fmt.Sprintf("%%0%dd", nameLength)
+	if name := fmt.Sprintf(format, 0); len(name) != nameLength {
+		// Sanity check that the generated format string creates strings of the right length
+		t.Fatalf("Length of generated name was not %d, got %d", nameLength, len(name))
+	}
+
+	var createdNodes []string
+	for i := 0; i < nodesToCreate; i++ {
+		name := fmt.Sprintf(format, i)
+		createdNodes = append(createdNodes, name)
+		path := testNode + "/" + name
+		if _, err := zk.Create(path, nil, 0, WorldACL(PermAll)); err != nil {
 			t.Fatalf("Create returned error: %+v", err)
-		} else if path != expect {
-			t.Fatalf("Create returned different path '%s' != '%s'", path, expect)
 		}
-		defer deleteNode(string(expect))
+		defer deleteNode(path)
 	}
 
-	children, _, err := zk.Children("/gozk-test-big")
+	children, _, err := zk.Children(testNode)
 	if err != nil {
 		t.Fatalf("Children returned error: %+v", err)
-	} else if len(children) != 10000 {
-		t.Fatal("Children returned wrong number of nodes")
+	}
+	sort.Strings(children)
+	if !reflect.DeepEqual(children, createdNodes) {
+		t.Fatal("Children did not return expected nodes")
 	}
 }
 
@@ -765,10 +760,16 @@ func TestSetWatchers(t *testing.T) {
 		}
 	}()
 
-	// we create lots of paths to watch, to make sure a "set watches" request
-	// on re-create will be too big and be required to span multiple packets
-	for i := 0; i < 1000; i++ {
-		testPath, err := zk.Create(fmt.Sprintf("/gozk-test-%d", i), []byte{}, 0, WorldACL(PermAll))
+	// we create lots of long paths to watch, to make sure a "set watches" request on will be too big and be broken
+	// into multiple packets. The size is chosen such that each packet can hold exactly 2 watches, meaning we should
+	// see half as many packets as there are watches.
+	const (
+		watches               = 50
+		watchedNodeNameFormat = "/gozk-test-%0450d"
+	)
+
+	for i := 0; i < watches; i++ {
+		testPath, err := zk.Create(fmt.Sprintf(watchedNodeNameFormat, i), []byte{}, 0, WorldACL(PermAll))
 		if err != nil {
 			t.Fatalf("Create returned: %+v", err)
 		}
@@ -852,9 +853,9 @@ func TestSetWatchers(t *testing.T) {
 	buf := make([]byte, bufferSize)
 	totalWatches := 0
 	actualReqs := setWatchReqs.Load().([]*setWatchesRequest)
-	if len(actualReqs) < 12 {
-		// sanity check: we should have generated *at least* 12 requests to reset watches
-		t.Fatalf("too few setWatchesRequest messages: %d", len(actualReqs))
+	if len(actualReqs) != watches/2 {
+		// sanity check: we should have generated exactly 25 requests to reset watches
+		t.Fatalf("Did not send exactly %d setWatches requests, got %d instead", watches/2, len(actualReqs))
 	}
 	for _, r := range actualReqs {
 		totalWatches += len(r.ChildWatches) + len(r.DataWatches) + len(r.ExistWatches)


### PR DESCRIPTION
Implements the new persistent watch types introduced in 3.6. Note that this code is currently active in production under LinkedIn's private fork of this repo.