### PR TITLE
Support the zxid introduced in 3.9.0 and relay pings to persistent watchers

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -51,9 +51,10 @@ const (
 	EventNodeChildrenChanged EventType = 4
 
 	// EventSession represents a session event.
-	EventSession     EventType = -1
-	EventNotWatching EventType = -2
-	EventWatching    EventType = -3
+	EventSession      EventType = -1
+	EventNotWatching  EventType = -2
+	EventWatching     EventType = -3
+	EventPingReceived EventType = -4
 )
 
 var (
@@ -65,6 +66,7 @@ var (
 		EventSession:             "EventSession",
 		EventNotWatching:         "EventNotWatching",
 		EventWatching:            "EventWatching",
+		EventPingReceived:        "EventPingReceived",
 	}
 )
 


### PR DESCRIPTION
Like the comment on Event.Zxid mentions, watch events now include the zxid as of ZK 3.9.0. Additionally, relaying pings to persistent watchers allows them to keep track of whether they are behind on consuming updates from ZK, particularly since the zxid is relayed.